### PR TITLE
Remove the Google Analytics Tracker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,9 +74,9 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "google-universal" # false (default), "google", "google-universal", "custom"
+  provider               :  false # false (default), "google", "google-universal", "custom"
   google:
-    tracking_id          :  "UA-190829886-1"
+    tracking_id          :  
 
 
 # Site Author


### PR DESCRIPTION
Hi, thanks for forking the homepage. Could you please remove the Google Analytics tracker from the forked version? Currently it's linked to my Google Analytics account. 

You can also create a tracker for your homepage using Google Analystics. 